### PR TITLE
new link for available methods

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -77,7 +77,7 @@ This can be fixed by modifying +iTMSTransporter.CMD+ (note that the following do
 
 <code>itms COMMAND [OPTIONS] [PACKAGE]</code>
 
-* +COMMAND+ - The command to run, which can be any one of {the <code>iTunes::Store::Transporter</code> methods}[http://ruby-doc.org/gems/docs/i/itunes_store_transporter-0.1.1/ITunes/Store/Transporter/ITMSTransporter.html]
+* +COMMAND+ - The command to run, which can be any one of {the <code>iTunes::Store::Transporter</code> methods}[https://github.com/sshaw/itunes_store_transporter/blob/master/lib/itunes/store/transporter/itms_transporter.rb#L36-L193]
 * +OPTIONS+ - These are quivalent to the given +COMMAND+'s options except they must be given in a strict long option format. For example <code>:apple_id => "X123"</code> would be <code>--apple-id=X123</code>. Boolean options can be negated with the <code>--no-</code> prefix. For more info see {each command's options}[http://ruby-doc.org/gems/docs/i/itunes_store_transporter-0.1.1/ITunes/Store/Transporter/ITMSTransporter.html].
 * +PACKAGE+ - The package or directory to operate on, if required by the command
 


### PR DESCRIPTION
old link http://ruby-doc.org/gems/docs/i/itunes_store_transporter-0.1.1/ITunes/Store/Transporter/ITMSTransporter.html was not working any more, http://www.rubydoc.info/gems/itunes_store_transporter/ITunes/Store/Transporter/ITMSTransporter or http://www.rubydoc.info/gems/itunes_store_transporter/ITunes/Store/Transporter/Command didn't seem helpful as well - so just link to the source here directly